### PR TITLE
Fix for error in right alignment on 32:9 screens

### DIFF
--- a/Blueprints/Lua/gui/gui_buttons_frame.lua
+++ b/Blueprints/Lua/gui/gui_buttons_frame.lua
@@ -14,6 +14,7 @@ local function check_and_rebuild_frame()
     if new_resolution ~= resolution or run_once_at_start == false then
         blue_prints.gui_button_frame = GUI.Frame(GUI.RectTransform(Vector2(1, 1)), nil)
         blue_prints.gui_button_frame.CanBeFocused = false
+        blue_prints.gui_button_frame.RectTransform.NonScaledSize = Point(new_resolution.X, new_resolution.Y)
 
         blue_prints.gui_button_frame_content = GUI.Frame(GUI.RectTransform(Vector2(0.1, 0.15), blue_prints.gui_button_frame.RectTransform, GUI.Anchor.CenterRight))
         blue_prints.gui_button_frame_list = GUI.ListBox(GUI.RectTransform(Vector2(1, 1), blue_prints.gui_button_frame_content.RectTransform, GUI.Anchor.BottomCenter))


### PR DESCRIPTION
forces `gui_button_frame` to be the size of the screen rather than being 16:9

As mentioned by @taswin on discord, this should fix the problem with the gui popup being centered on non 16:9 screens.